### PR TITLE
Fix bug with regex and extensions with dashes

### DIFF
--- a/lib/filetype-color-view.js
+++ b/lib/filetype-color-view.js
@@ -185,7 +185,7 @@ module.exports = FiletypeColorView = (function(_super) {
     };
 
     FiletypeColorView.prototype.clearElement = function(el) {
-        el.className = el.className.replace(/\sfiletype-color-[\w]+/, '');
+        el.className = el.className.replace(/\sfiletype-color-[\S]+/, '');
     };
 
     return FiletypeColorView;


### PR DESCRIPTION
Thank you for the great plugin. I was wondering how to do something like this!

A small fix for something I found:

Should a file extension with a dash exist (for example, ".rbenv-vars", or ".ruby-version") the regex that clears the element's filetype-color- class would not properly clear all of it. For example, this would result, on multiple toggles of the package using ctrl-alt-cmd-b, in the following:

toggle on: class="name icon icon-file-text filetype-color-ruby-version"
toggle off: class="name icon icon-file-text-version"
toggle on: class="name icon icon-file-text-version filetype-color-ruby-version"
toggle off: class="name icon icon-file-text-version-version"

etc.

The regex has been corrected to remove everything after "filetype-color-" until it encounters the end of the class name (a whitespace character): http://cl.ly/image/2j1O2v3W1v2M
