### PR TITLE
[FIX] Update filetype-color.cson

### DIFF
--- a/keymaps/filetype-color.cson
+++ b/keymaps/filetype-color.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-alt-cmd-b': 'filetype-color:toggle'


### PR DESCRIPTION
Fix depricated selector https://github.com/sommerper/filetype-color/issues/11  :+1:
To work with latest Atom.io version without warnings. :gem: 