### PR TITLE
Add Color for Ruby filetype .rb

### DIFF
--- a/stylesheets/filetype-color.less
+++ b/stylesheets/filetype-color.less
@@ -148,6 +148,11 @@
     color: #B13429;
 }
 
+.filetype-color-rb
+{
+    color: #CC342D;
+}
+
 .filetype-color-eot, .filetype-color-svg, .filetype-color-ttf, .filetype-color-woff
 {
     color: #a8d173;


### PR DESCRIPTION
With lack of documentation on the brand, used the color #CC342D from
ruby-lang.org styles
